### PR TITLE
Upgrade to FDO 23.08

### DIFF
--- a/com.steamgriddb.SGDBoop.yml
+++ b/com.steamgriddb.SGDBoop.yml
@@ -1,6 +1,6 @@
 app-id: com.steamgriddb.SGDBoop
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 command: SGDBoop
 finish-args:


### PR DESCRIPTION
21.08 is gonna be end-of-life pretty soon, so let's just bump directly to 23.08.

I tested this out with both the test popup on the SGDBoop page, as well as directly replacing a grid for one of the games in my library.